### PR TITLE
fixed path translation of tables

### DIFF
--- a/src/_manifest.lua
+++ b/src/_manifest.lua
@@ -65,6 +65,7 @@
 		"actions/vstudio/vs2010_vcxproj_filters.lua",
 		"actions/vstudio/vs2012.lua",
 		"actions/vstudio/vs2013.lua",
+		"actions/vstudio/vs2015.lua",
 
 		-- Xcode action
 		"actions/xcode/_xcode.lua",

--- a/src/actions/vstudio/vs2010_vcxproj.lua
+++ b/src/actions/vstudio/vs2010_vcxproj.lua
@@ -79,7 +79,7 @@
 		_p(2,'<UseDebugLibraries>%s</UseDebugLibraries>', iif(optimisation(cfg) == "Disabled","true","false"))
 		_p(2,'<CharacterSet>%s</CharacterSet>',iif(cfg.flags.Unicode,"Unicode","MultiByte"))
 
-		local toolsets = { vs2012 = "v110", vs2013 = "v120" }
+		local toolsets = { vs2012 = "v110", vs2013 = "v120", vs2015 = "v140" }
 		local toolset = toolsets[_ACTION]
 		if toolset then
 			_p(2,'<PlatformToolset>%s</PlatformToolset>', toolset)
@@ -561,6 +561,8 @@
 --
 
 	function vc2010.header(targets)
+		local action = premake.action.current()
+
 		io.eol = "\r\n"
 		_p('<?xml version="1.0" encoding="utf-8"?>')
 
@@ -569,7 +571,12 @@
 			t = ' DefaultTargets="' .. targets .. '"'
 		end
 
-		_p('<Project%s ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">', t)
+		local tv = ''
+		if action.vstudio.toolsVersion then
+			tv = string.format(' ToolsVersion="%s"', action.vstudio.toolsVersion)
+		end
+
+		_p('<Project%s%s xmlns="http://schemas.microsoft.com/developer/msbuild/2003">', t, tv)
 	end
 
 

--- a/src/actions/vstudio/vs2015.lua
+++ b/src/actions/vstudio/vs2015.lua
@@ -1,0 +1,57 @@
+--
+-- vs2015.lua
+-- Baseline support for Visual Studio 2015.
+-- Copyright (c) 2015 Jason Perkins and the Premake project
+--
+
+	premake.vstudio.vc2015 = {}
+	local vc2015 = premake.vstudio.vc2015
+	local vstudio = premake.vstudio
+
+
+---
+-- Register a command-line action for Visual Studio 2015.
+---
+
+	newaction
+	{
+		trigger         = "vs2015",
+		shortname       = "Visual Studio 2015",
+		description     = "Generate Microsoft Visual Studio 2015 project files",
+		os              = "windows",
+
+		valid_kinds     = { "ConsoleApp", "WindowedApp", "StaticLib", "SharedLib" },
+
+		valid_languages = { "C", "C++", "C#"},
+
+		valid_tools     = {
+			cc     = { "msc"   },
+			dotnet = { "msnet" },
+		},
+
+		onsolution = function(sln)
+			premake.generate(sln, "%%.sln", vstudio.sln2005.generate)
+		end,
+
+		onproject = function(prj)
+			if premake.isdotnetproject(prj) then
+				premake.generate(prj, "%%.csproj", vstudio.cs2005.generate)
+				premake.generate(prj, "%%.csproj.user", vstudio.cs2005.generate_user)
+			else
+			premake.generate(prj, "%%.vcxproj", premake.vs2010_vcxproj)
+			premake.generate(prj, "%%.vcxproj.user", premake.vs2010_vcxproj_user)
+			premake.generate(prj, "%%.vcxproj.filters", vstudio.vc2010.generate_filters)
+			end
+		end,
+
+
+		oncleansolution = premake.vstudio.cleansolution,
+		oncleanproject  = premake.vstudio.cleanproject,
+		oncleantarget   = premake.vstudio.cleantarget,
+
+		vstudio = {
+			solutionVersion = "12",
+			targetFramework = "4.5.2",
+			toolsVersion    = "14.0",
+		}
+	}

--- a/src/host/path_translate.c
+++ b/src/host/path_translate.c
@@ -43,7 +43,7 @@ int path_translate(lua_State* L)
 		lua_newtable(L);
 		lua_pushnil(L);
 		while (lua_next(L, 1)) {
-			const char* value = luaL_checkstring(L, 4);
+			const char* value = luaL_checkstring(L, -1);
 			translate(buffer, value, sep[0]);
 			lua_pop(L, 1);
 

--- a/tests/actions/vstudio/cs2005/projectelement.lua
+++ b/tests/actions/vstudio/cs2005/projectelement.lua
@@ -72,3 +72,13 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 		]]
 	end
+
+	function suite.On2015()
+		_ACTION = "vs2015"
+		prepare()
+		test.capture [[
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+		]]
+	end
+

--- a/tests/actions/vstudio/sln2005/header.lua
+++ b/tests/actions/vstudio/sln2005/header.lua
@@ -77,3 +77,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
 		]]
 	end
+
+
+	function suite.On2015()
+		_ACTION = "vs2015"
+		prepare()
+		test.capture [[
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2015
+		]]
+	end

--- a/tests/actions/vstudio/vc2010/test_config_props.lua
+++ b/tests/actions/vstudio/vc2010/test_config_props.lua
@@ -76,3 +76,16 @@
 	</PropertyGroup>
 		]]
 	end
+
+	function suite.structureIsCorrect_onDefaultValues_on2015()
+		_ACTION = "vs2015"
+		prepare()
+		test.capture [[
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+		<ConfigurationType>Application</ConfigurationType>
+		<UseDebugLibraries>true</UseDebugLibraries>
+		<CharacterSet>MultiByte</CharacterSet>
+		<PlatformToolset>v140</PlatformToolset>
+	</PropertyGroup>
+		]]
+	end


### PR DESCRIPTION
fixes the "invalid key to 'next'" error when generating vs2005 or vs2008 projects
