### PR TITLE
Added frameworkdirs option.

### DIFF
--- a/src/actions/xcode/xcode_common.lua
+++ b/src/actions/xcode/xcode_common.lua
@@ -828,6 +828,7 @@
 
 		xcode.printlist(cfg.includedirs, 'HEADER_SEARCH_PATHS')
 		xcode.printlist(cfg.libdirs, 'LIBRARY_SEARCH_PATHS')
+		xcode.printlist(cfg.frameworkdirs, 'FRAMEWORK_SEARCH_PATHS')
 		
 		_p(4,'OBJROOT = "%s";', cfg.objectsdir)
 

--- a/src/base/api.lua
+++ b/src/base/api.lua
@@ -241,6 +241,12 @@
 			linkagecopy = true,
 		},
 
+		frameworkdirs =
+		{
+			kind = "dirlist",
+			scope = "config",
+		},
+
 		linkoptions =
 		{
 			kind  = "list",


### PR DESCRIPTION
This should now support FRAMEWORK_SEARCH_PATHS in xcode_common.lua.
This will allow frameworks to exist in non sdk paths.

configuration "macosx"
frameworkdirs { "Library/MacOS/SDL2-2.0.3" }
linkoptions { "-framework SDL2" }
